### PR TITLE
Clear chat universal switch fixes

### DIFF
--- a/TwitchPlugin/TwitchPlugin/Actions/UniversalStateSwitch.cs
+++ b/TwitchPlugin/TwitchPlugin/Actions/UniversalStateSwitch.cs
@@ -117,11 +117,11 @@
                 this.Plugin.Log.Info($"Running command '{toggleValue}'");
                 if(toggleValue == item.OffStateName)
                 {
-                    item.SwitchOff();
+                    item.SwitchOn();
                 }
                 else
                 {
-                    item.SwitchOn();
+                    item.SwitchOff();
                 }
             }
             return true;

--- a/TwitchPlugin/TwitchPlugin/Authenticator/AuthenticationServer.cs
+++ b/TwitchPlugin/TwitchPlugin/Authenticator/AuthenticationServer.cs
@@ -28,8 +28,7 @@
             "moderator:manage:chat_settings",
             "channel:moderate",
             "user:edit:broadcast",
-            "channel_commercial", // this is scope from twitch API v5. Rfc does not currently allow to use /commercial command without it. This will probably brake when twitch drop support for API v5.
-            "channel_editor", // This will probably brake when twitch drop support for API v5.
+            "moderator:manage:chat_messages", 
             "user:read:email"
         };
 

--- a/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
+++ b/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
@@ -15,7 +15,7 @@ displayName: Twitch
 pluginFileName: TwitchPlugin.dll
 
 # Plugin version.
-version: 5.6.1.20004
+version: 5.6.1.20005
 
 # Author of the plugin. The author can be a company or an individual developer.
 author: Andrei Laperie, Loupedeck

--- a/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
+++ b/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
@@ -15,7 +15,7 @@ displayName: Twitch
 pluginFileName: TwitchPlugin.dll
 
 # Plugin version.
-version: 5.6.1.20005
+version: 5.6.2.20005
 
 # Author of the plugin. The author can be a company or an individual developer.
 author: Andrei Laperie, Loupedeck


### PR DESCRIPTION
fixing issues:
'Clear chat'  not working (caused by insufficient scopes in authentication)
Universal switch logic is  reversed ('ensure on' turns it off and vice versa)
