### PR TITLE
Authorization code authentication is back for Twitch Plugin

### DIFF
--- a/TwitchPlugin/TwitchPlugin/Authenticator/AuthenticationServer.cs
+++ b/TwitchPlugin/TwitchPlugin/Authenticator/AuthenticationServer.cs
@@ -69,7 +69,7 @@
                 this._listener.Prefixes.Clear();
                 this._listener.Prefixes.Add(this.RedirectUrl);
                 this._listener.Start();
-                this._listener.BeginGetContext(new AsyncCallback(this.ListenerCallback), this._listener);
+                this._listener.BeginGetContext(this.ListenerCallback, this._listener);
                 return true;
             }
             catch (Exception e)
@@ -91,11 +91,16 @@
                 TwitchPlugin.PluginLog.Error("Twitch AuthenticationServer: Error starting listener");
                 return false;
             }
-            /* we are using OAuth Implicit grant flow https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#oidc-implicit-grant-flow
-             * 1 - step authorization: we send all this and then wait for the response where code is sent
+            /* we are using OAuth Authorization code flow: https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#oidc-authorization-code-grant-flow 
+             * 
+             * 2-step authorization: 
+             * 1. We authorize the app (and listen on redirect URL for authorization dode (see ListenerCallback)
+             * 2. Once we receive the code, we form a HTTP Post Request and, if successful, receive all tokens (access,refresh and ID)
              */
 
-            var oauthUrl = "https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=" + TwitchPlugin.Proxy.twitchApi.Settings.ClientId + $"&redirect_uri={this.RedirectUrl}" + "&scope=" + String.Join("+", Scopes);
+            //Note: Using TwitchApi method to create oauth url did not work out because of scopes ... seems that no all the scopes needed are available there.
+                        
+            var oauthUrl = "https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=" + TwitchPlugin.Proxy.twitchApi.Settings.ClientId  + $"&redirect_uri={this.RedirectUrl}" + "&scope=" + String.Join("+", Scopes);
 
             try
             {
@@ -135,83 +140,75 @@
             }
 
         }
-        private void ListenerCallback(IAsyncResult result)
+        private async void ListenerCallback(IAsyncResult result)
         {
             TwitchPlugin.PluginLog.Info("Twitch AuthenticationServer ListenerCallback");
 
-            if (!this._listener.IsListening)
-            {
-                TwitchPlugin.PluginLog.Warning("Go to ListenerCallback but Listener is not listening ?");
-                this.OnTokenError.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_MISC));
-                return;
-            }
-
-            var finalResponseString = AuthenticationServer.ResponseString;
-            var context = this._listener.EndGetContext(result);
-            var continueListening = false;
             try
             {
-                /* this is kind of response we are receiving 
-                 http://localhost:3000/
-                    #access_token=73gl5dipwta5fsfma3ia05woyffbp
-                    &id_token=eyJhbGciOiJSUzI1NiIsInR5cC6IkpXVCIsImtpZCI6IjEifQ...
-                    &scope=channel%253Amanage%253Apolls+channel%253Aread%253Apolls+openid
-                    &state=c3ab8aa609ea11e793ae92361f002671
-                    &token_type=bearer
-                 */
-
-                //Access token needs to be extracted from the fragment portion of the URI we receive to the server
-
-                if (context.Request.QueryString.AllKeys.Contains("error"))
+                if (!this._listener.IsListening)
                 {
-                    TwitchPlugin.PluginLog.Warning("Cannot get access token, possibly invalid client secret");
-                    finalResponseString = this.GetAuthErrorPage($"Error authenticating - \"{context.Request.QueryString["error"]}\" - \"{context.Request.QueryString["error_description"]}\"");
-                    this.OnTokenError?.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_SECRET));
+                    TwitchPlugin.PluginLog.Warning("Go to ListenerCallback but Listener is not listening ?");
+                    this.OnTokenError.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_MISC));
+                    return;
                 }
-                else if (!context.Request.QueryString.AllKeys.Contains("access_token"))
+
+                var finalResponseString = AuthenticationServer.ResponseString;
+                var context = this._listener.EndGetContext(result);
+
+                var code = context.Request.QueryString["code"];
+                
+                //FIXME !! For whatever reason, whenever GetAccessTokenFromCodeAsync is used, the response ('success') can no longer be written!
+                //var response = await TwitchPlugin.Proxy.twitchApi.Auth.GetAccessTokenFromCodeAsync(code, this._clientSecret, this._redirectUrl);
+
+                var client = new HttpClient();
+
+                var tokenResponse = await client.PostAsync(new Uri("https://id.twitch.tv/oauth2/token?"),
+                    new FormUrlEncodedContent(new[]
+                    {
+                        new KeyValuePair<String, String>("client_id", TwitchPlugin.Proxy.twitchApi.Settings.ClientId),
+                        new KeyValuePair<String, String>("client_secret", TwitchPlugin.Proxy.twitchApi.Settings.Secret),
+                        new KeyValuePair<String, String>("grant_type", "authorization_code"),
+                        new KeyValuePair<String, String>("redirect_uri", this.RedirectUrl),
+                        new KeyValuePair<String, String>("code", code)
+                    }));
+  
+                if (tokenResponse.StatusCode == HttpStatusCode.OK)
                 {
+                    var rawtext = await tokenResponse.Content.ReadAsStringAsync();
+                    var authResp = JsonConvert.DeserializeObject<AuthCodeResponse>(rawtext);
 
-                    //The browser is redirectred to localhost:3000/#access_toke=xxxxx   
-                    //But we are not receiving it here. We need to send javacript to 
-                    TwitchPlugin.PluginLog.Warning("Intial request received, creating redirect to get auth code");
-                    finalResponseString = $@"
-<html><head><body><script type ='text/javascript'>
-const urlParams = new URLSearchParams(window.location.hash.replace('#', '?'));
-const token = urlParams.get('access_token');
-const state = urlParams.get('state');
-if (token && token.length)
-    window.location.href = '{context.Request.Url}/redirect/?access_token=' + token + '&state=' + state;
-</script></body>";
-                    continueListening = true;
-                   
-                    this._listener.BeginGetContext(new AsyncCallback(this.ListenerCallback), this._listener);
-                }
-                else if (context.Request.QueryString.AllKeys.Contains("access_token"))
-                { 
-                    TwitchPlugin.PluginLog.Info($"Got access token: {context.Request.Url.AbsoluteUri}");
-                    var frag = context.Request.Url.AbsoluteUri;
-                    //Should be like access_token=73gl5dipwta5fsfma3ia05woyffbp
-                    var accessToken = frag.Split("&")[0].Split('=')[1];
-                    TwitchPlugin.PluginLog.Info($"Got access token: {accessToken}");
-
-                    if (TwitchProxy.ValidateAccessToken(accessToken, out var validationResp))
+                    if (TwitchProxy.ValidateAccessToken(authResp.AccessToken, out var validationResp))
                     {
                         //Note: Unless we are completely paranoid, we won't validate the scope here
-                        this.OnTokenReceived?.BeginInvoke(this, new AccessTokenReceivedEventArgs(accessToken, null, validationResp));
+                        this.OnTokenReceived?.BeginInvoke(this, new AccessTokenReceivedEventArgs(authResp.AccessToken, authResp.RefreshToken, validationResp));
                     }
                     else
                     {
                         TwitchPlugin.PluginLog.Warning("Token validation failed, ");
-                        finalResponseString = this.GetAuthErrorPage("Error validating access token");
-                        this.OnTokenError?.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_MISC));
+                        finalResponseString = this.GetAuthErrorPage("Token validation failed");
+                        this.OnTokenError?.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_VALIDATION));
                     }
                 }
                 else
                 {
-                    TwitchPlugin.PluginLog.Warning("authserver: Received no parameters. Continue listening");
-                    continueListening = true;
+                    TwitchPlugin.PluginLog.Warning("Cannot get access token, possibly invalid client secret");
+                    finalResponseString = this.GetAuthErrorPage("Invalid secret");
+                    this.OnTokenError?.BeginInvoke(this, new AccessTokenErrorEventArgs(AccessTokenErrorEventArgs.TokenError.ERROR_SECRET));
                 }
 
+                { 
+                    HttpListenerResponse response = context.Response;
+                    byte[] buffer = Encoding.UTF8.GetBytes(finalResponseString);
+                    response.ContentLength64 = buffer.Length;
+                    Stream output = response.OutputStream;
+                    output.Write(buffer, 0, buffer.Length);
+                    output.Close();
+                    //this.TokenReceived?.Invoke(this, response /*JsonConvert.DeserializeObject<AuthCodeResponse>(response)*/);
+                    //await writer.WriteAsync(finalResponseString);
+                }
+                TwitchPlugin.PluginLog.Info("Auth successful, existing callback");
+                
             }
             catch (Exception e)
             {
@@ -220,11 +217,9 @@ if (token && token.length)
             }
             finally
             {
-                this.WriteHttpResponse(context, finalResponseString);
-
                 try
                 {
-                    if (this._listener.IsListening && !continueListening)
+                    if (this._listener.IsListening)
                     {
                         this._listener.Stop();
                     }

--- a/TwitchPlugin/TwitchPlugin/Models/EventArgs.cs
+++ b/TwitchPlugin/TwitchPlugin/Models/EventArgs.cs
@@ -57,10 +57,12 @@
     {
         public String UserName { get; private set; }
         public String AccessToken { get; private set; }
-        public TokensUpdatedEventArg(String _userName, String _accessToken)
+        public String RefreshToken { get; private set; }
+        public TokensUpdatedEventArg(String _userName, String _accessToken, String _refreshToken)
         {
             this.UserName = _userName;
             this.AccessToken = _accessToken;
+            this.RefreshToken = _refreshToken;
         }
     }
 }

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -56,9 +56,10 @@ namespace Loupedeck.TwitchPlugin
             //Say, 20 seconds before an actual expiration.
             //One hour interval
             this._refreshTokenTimer.Interval = 3600 * 1000;
+            this._refreshTokenTimer.AutoReset = true; //Repeatedly fire
 
             //1000 * (expiresIn > WakeupBeforeExpirationS ? (expiresIn - WakeupBeforeExpirationS) : WakeupBeforeExpirationS);
-            
+
             this.RefreshToken = refreshToken;
             this.TokenExpiresIn = expiresIn;
 

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -66,21 +66,15 @@ namespace Loupedeck.TwitchPlugin
 
             this._refreshTokenTimer.Enabled = true;
 
-            TwitchPlugin.PluginLog.Info($"Refresh timer enabled: {this._refreshTokenTimer.Enabled}, Token expires in {expiresIn}");
+            TwitchPlugin.PluginLog.Info($"Token timer enabled: {this._refreshTokenTimer.Enabled},  Timer will fire in {this._refreshTokenTimer.Interval / 1000}s Token expires in {expiresIn}");
         }
 
         private void OnRefreshTokenTimerTick(Object _, Object _1)
         {
-            //We validate the token hourly. If it's less than an hour to expire, we refresh it.
-            if (! TwitchProxy.ValidateAccessToken(this.twitchApi.Settings.AccessToken, out var validationResp))
-            {
-                this.TokenExpiresIn = 0;
-            }
-            else
-            { 
-                this.TokenExpiresIn = validationResp.ExpiresIn;
-            }
+            TwitchPlugin.PluginLog.Info($"In Token Refresh timer");
+            this.TokenExpiresIn = ! TwitchProxy.ValidateAccessToken(this.twitchApi.Settings.AccessToken, out var validationResp) ? 0 : validationResp.ExpiresIn;
 
+            //We validate the token hourly. If it's less than an hour to expire, we refresh it.
             if (this.TokenExpiresIn < 3600)
             {
                 TwitchPlugin.PluginLog.Info("It's time to refresh the token!");

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -55,7 +55,8 @@ namespace Loupedeck.TwitchPlugin
 
             //Say, 20 seconds before an actual expiration.
             //One hour interval
-            this._refreshTokenTimer.Interval = 3600 * 1000;
+            this._refreshTokenTimer.Interval = (expiresIn < 3600.0 ? expiresIn: 3600.0 ) * 1000;
+
             this._refreshTokenTimer.AutoReset = true; //Repeatedly fire
 
             //1000 * (expiresIn > WakeupBeforeExpirationS ? (expiresIn - WakeupBeforeExpirationS) : WakeupBeforeExpirationS);

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -40,7 +40,6 @@ namespace Loupedeck.TwitchPlugin
         public Boolean IsConnected => (this._twitchClient?.IsConnected ?? false) == true;
 
         public EventHandler<(String, Exception)> IncorrectLogin { get; set; }
-        
         private String RefreshToken { get; set; } = null;
         private Int32 TokenExpiresIn { get; set; } = 0;
 
@@ -107,6 +106,9 @@ namespace Loupedeck.TwitchPlugin
 
         public void PreconfiguredConnect(PluginPreferenceAccount account, ValidateAccessTokenResponse validate) =>
             this.OnAccessTokenReceived(this, new AccessTokenReceivedEventArgs(account.AccessToken, account.RefreshToken, validate));
+
+        public void PreconfiguredConnect(String accessToken, String refreshToken, String userId, String login, Int32 expiresIn) =>
+            this.OnAccessTokenReceived(this, new AccessTokenReceivedEventArgs(accessToken, refreshToken, userId, login, expiresIn));
 
         private void OnAccessTokenReceived(Object sender, AccessTokenReceivedEventArgs arg)
         {
@@ -299,6 +301,10 @@ namespace Loupedeck.TwitchPlugin
 
                     this.twitchApi.Settings.AccessToken = result.AccessToken;
 
+                    if (TwitchProxy.ValidateAccessToken(this.twitchApi.Settings.AccessToken, out var validationResp))
+                    {
+                        this.PreconfiguredConnect(this.twitchApi.Settings.AccessToken, result.RefreshToken, validationResp.UserId, validationResp.Login, result.ExpiresIn);
+                    }
 
                     //See above the note about reconnection bug
                     this.DisconnectAndKillTwitchClient();

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -275,7 +275,7 @@ namespace Loupedeck.TwitchPlugin
             this.DisposeTwitchClient();
         }
 
-        private void RequestRefreshAccessToken(String inRefreshToken=null)
+        public void RequestRefreshAccessToken(String inRefreshToken=null)
         {
             var refreshToken = String.IsNullOrEmpty(inRefreshToken) ? this.RefreshToken : inRefreshToken;
 

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.Connectivity.cs
@@ -40,6 +40,52 @@ namespace Loupedeck.TwitchPlugin
         public Boolean IsConnected => (this._twitchClient?.IsConnected ?? false) == true;
 
         public EventHandler<(String, Exception)> IncorrectLogin { get; set; }
+        
+        private String RefreshToken { get; set; } = null;
+        private Int32 TokenExpiresIn { get; set; } = 0;
+
+        private readonly System.Timers.Timer _refreshTokenTimer = null; 
+        
+
+        private const Int32 WakeupBeforeExpirationS = 1800; /*Wake up seconds before expiration timer*/
+
+        private void SetRefreshToken(String refreshToken,Int32 expiresIn)
+        {
+            this._refreshTokenTimer.Enabled = false;
+
+            //Say, 20 seconds before an actual expiration.
+            //One hour interval
+            this._refreshTokenTimer.Interval = 3600 * 1000;
+
+            //1000 * (expiresIn > WakeupBeforeExpirationS ? (expiresIn - WakeupBeforeExpirationS) : WakeupBeforeExpirationS);
+            
+            this.RefreshToken = refreshToken;
+            this.TokenExpiresIn = expiresIn;
+
+            this._refreshTokenTimer.Enabled = true;
+
+            TwitchPlugin.PluginLog.Info($"Refresh timer enabled: {this._refreshTokenTimer.Enabled}, Token expires in {expiresIn}");
+        }
+
+        private void OnRefreshTokenTimerTick(Object _, Object _1)
+        {
+            //We validate the token hourly. If it's less than an hour to expire, we refresh it.
+            if (! TwitchProxy.ValidateAccessToken(this.twitchApi.Settings.AccessToken, out var validationResp))
+            {
+                this.TokenExpiresIn = 0;
+            }
+            else
+            { 
+                this.TokenExpiresIn = validationResp.ExpiresIn;
+            }
+
+            if (this.TokenExpiresIn < 3600)
+            {
+                TwitchPlugin.PluginLog.Info("It's time to refresh the token!");
+                this.RequestRefreshAccessToken(this.RefreshToken);
+            }
+                
+        }
 
         /* Starts an authentication process, upon successful completion of which the connection should start */
         public void StartAuthentication()
@@ -68,7 +114,7 @@ namespace Loupedeck.TwitchPlugin
 
         private void OnAccessTokenReceived(Object sender, AccessTokenReceivedEventArgs arg)
         {
-            TwitchPlugin.PluginLog.Info("Access token received");
+            TwitchPlugin.PluginLog.Info($"Access token received, token expires in {arg.ExpiresIn}");
             if (!String.IsNullOrEmpty(this.twitchApi.Settings.AccessToken) && this.IsConnected)
             {
                 TwitchPlugin.PluginLog.Info("Already connected, and access token non-empty.");
@@ -91,8 +137,11 @@ namespace Loupedeck.TwitchPlugin
             //Received access token! Can proceed with connecting
             this.twitchApi.Settings.AccessToken = arg.AccessToken;
 
+            //Storing refresh token. We will store that and this.twitchApi.Settings.AccessToken to account upon succesful connection 
+            this.SetRefreshToken(arg.RefreshToken, arg.ExpiresIn);
+
             //Updating plugin so that tokens will be stored
-            this.TokensUpdated?.Invoke(sender, new TokensUpdatedEventArg(this._userInfo.Login, this.twitchApi.Settings.AccessToken));
+            this.TokensUpdated?.Invoke(sender, new TokensUpdatedEventArg(this._userInfo.Login, this.twitchApi.Settings.AccessToken, this.RefreshToken));
 
             //Note: We need to verify situation when DoConnect fails but authentication succeeds \
             if (Helpers.TryExecuteFunc(() => this.DoConnect(), out var connResult) && connResult)
@@ -209,10 +258,13 @@ namespace Loupedeck.TwitchPlugin
 
             this.IncorrectLogin?.Invoke(sender, (e.Exception.Username, e.Exception));
         }
+
+        private Boolean _refreshAccessTokenRequestBlocked = false;
+
         private void OnAccessTokenExpired(Object sender, EventArgs e)
         {
             TwitchPlugin.PluginLog.Info("TwitchPlugin OnAccessTokenExpired");
-            //FIXME: Here we need to show the browser? 
+            this.RequestRefreshAccessToken(this.RefreshToken);
         }
 
         private void DisconnectAndKillTwitchClient()
@@ -225,6 +277,71 @@ namespace Loupedeck.TwitchPlugin
 
             this.AppDisconnected?.BeginInvoke(this, EventArgs.Empty);
             this.DisposeTwitchClient();
+        }
+
+        private void RequestRefreshAccessToken(String inRefreshToken=null)
+        {
+            var refreshToken = String.IsNullOrEmpty(inRefreshToken) ? this.RefreshToken : inRefreshToken;
+
+            TwitchPlugin.PluginLog.Info("TwitchPlugin RequestRefreshAccessToken");
+
+            if (this._refreshAccessTokenRequestBlocked)
+            {
+                TwitchPlugin.PluginLog.Warning("TwitchPlugin Already requesting");
+                return;
+            }
+
+            this._refreshAccessTokenRequestBlocked = true;
+
+            try
+            {
+                var result = TwitchPlugin.Proxy.twitchApi.Auth.RefreshAuthTokenAsync(refreshToken, this.twitchApi.Settings.Secret).Result;
+
+                if( result != null)
+                {
+                    TwitchPlugin.PluginLog.Info($"Tokens refreshed successfully, new token expires in {result.ExpiresIn}s or {result.ExpiresIn/60}min ");
+
+                    this.twitchApi.Settings.AccessToken = result.AccessToken;
+
+
+                    //See above the note about reconnection bug
+                    this.DisconnectAndKillTwitchClient();
+                    TwitchPlugin.PluginLog.Info("Phoneix rises from the ashes!");
+                    this.InitializeTwitchClient();
+                    this.DoConnect();
+                    
+                    /*
+                    this._twitchClient.Initialize(
+                        credentials: new ConnectionCredentials(this._userInfo.Login, this.twitchApi.Settings.AccessToken),
+                        channel: this._userInfo.Login);
+
+                    this._twitchClient.Reconnect();
+                    */
+
+                    this.SetRefreshToken(result.RefreshToken, result.ExpiresIn);
+                    //Note that in Refresh response we naturally don't receive userid/login - we use the same as before. 
+                    //this.OnAccessTokenReceived(this, new AccessTokenReceivedEventArgs(result.AccessToken, result.RefreshToken, this._userInfo.Id, this._userInfo.Login, result.ExpiresIn));
+                    
+                    this.TokensUpdated?.Invoke(this, new TokensUpdatedEventArg(this._userInfo.Login, this.twitchApi.Settings.AccessToken, this.RefreshToken));
+                }
+                else
+                {
+                    throw new InvalidAccessTokenException();
+                }
+                
+            }
+            catch (Exception e)
+            {
+                TwitchPlugin.PluginLog.Warning(e, "Twitch: Failed to refresh token. Manual login is needed");
+                //To reset the access tokens
+                this.IncorrectLogin.Invoke(this, (this._userInfo.Login, e));
+                
+            }
+            finally
+            {
+                this._refreshAccessTokenRequestBlocked = false;
+            }
+            
         }
     }
 }

--- a/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.cs
+++ b/TwitchPlugin/TwitchPlugin/Proxy/TwitchProxy.cs
@@ -79,6 +79,8 @@
         }
         private void DisposeTwitchClient()
         {
+            this._refreshTokenTimer.Enabled = false;
+
             this.StopViewersUpdateTimer(this, null);
 
             if (this._twitchClient == null)
@@ -124,6 +126,11 @@
             });
 
             this.OnTwitchAccessTokenExpired += this.OnAccessTokenExpired;
+
+            this._refreshTokenTimer = new System.Timers.Timer();
+            this._refreshTokenTimer.AutoReset = false;
+            this._refreshTokenTimer.Elapsed += (e, s) => this.OnRefreshTokenTimerTick(null, null);
+            this._refreshTokenTimer.Enabled = false;
 
             this._viewersUpdatetimer = new System.Timers.Timer();
             this._viewersUpdatetimer.AutoReset = true;

--- a/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
+++ b/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
@@ -125,11 +125,10 @@
             TwitchPlugin.PluginLog.Info("TwitchPlugin OnTwitchAccountOnLogoutRequested: Reporting Logout");
 
             // Asking Proxy here.,
-            this._twitchAccount.AccessToken = null;
-            this._twitchAccount.RefreshToken = null;
+
             TwitchPlugin.Proxy.Disconnect();
             TwitchPlugin.PluginLog.Info("Reporting Logout");
-            this._twitchAccount.ReportLogout(); //So that we force login for the next time
+            this.CleanTokensAndLogout();
         }
 
         private void OnError(Object sender, Exception e) => TwitchPlugin.PluginLog.Warning(e, $"TwitchAPI OnError received: {e.Message}");
@@ -154,9 +153,7 @@
             if( this._incorrectLoginErrors++ > MaxIncorrectLoginErrors )
             {
                 TwitchPlugin.PluginLog.Warning("Too many incorrect logins. Reporting logout");
-
-                // Incorrect login happens when we are re-authenticating. Let's ignore it for now
-                this._twitchAccount.ReportLogout();
+                this.CleanTokensAndLogout();
             }
         }
 
@@ -179,7 +176,7 @@
             this.OnPluginStatusChanged(Loupedeck.PluginStatus.Normal, "Connected!");
         }
 
-        private void CleanTockensAndLogout()
+        private void CleanTokensAndLogout()
         {
             this._twitchAccount.AccessToken = null;
             this._twitchAccount.RefreshToken = null;
@@ -243,13 +240,13 @@
                     catch (InvalidAccessTokenException ex)
                     {
                         TwitchPlugin.PluginLog.Info(ex, $"TwitchPlugin Twitch: Failed to refresh token. Manual login is needed.");
-                        this.CleanTockensAndLogout();
+                        this.CleanTokensAndLogout();
                     }
                 }
                 else
                 {
                     TwitchPlugin.PluginLog.Info($"TwitchPlugin OnOnlineFileContentReceived: token not cached or invalid. Need manual relogin. Access Token Empty={String.IsNullOrEmpty(this._twitchAccount.AccessToken)}. Refresh Token Empty={String.IsNullOrEmpty(this._twitchAccount.RefreshToken)}");
-                    this.CleanTockensAndLogout();
+                    this.CleanTokensAndLogout();
                 }
             }
         }

--- a/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
+++ b/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
@@ -166,10 +166,10 @@
             TwitchPlugin.PluginLog.Info($"Twitch tokens updated for : {args.UserName}");
 
             this._twitchAccount.AccessToken = args.AccessToken;
-            this._twitchAccount.RefreshToken = "";
+            this._twitchAccount.RefreshToken = args.RefreshToken;
 
             //Setting status and storing the tokens
-            this._twitchAccount.ReportLogin(args.UserName, this._twitchAccount.AccessToken, "");
+            this._twitchAccount.ReportLogin(args.UserName, this._twitchAccount.AccessToken, this._twitchAccount.RefreshToken);
         }
 
         private void OnConnected(Object sender, EventArgs e)
@@ -218,6 +218,7 @@
 
 
             if (!String.IsNullOrEmpty(this._twitchAccount.AccessToken)
+                && !String.IsNullOrEmpty(this._twitchAccount.RefreshToken)
                 && TwitchProxy.ValidateAccessToken(this._twitchAccount.AccessToken, out var validationResp) )
             {
                 TwitchPlugin.PluginLog.Info("Attempting to connect with cached tokens");

--- a/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
+++ b/TwitchPlugin/TwitchPlugin/TwitchPlugin.cs
@@ -122,13 +122,13 @@
         private void OnTwitchAccountOnLogoutRequested(Object sender, EventArgs e)
         {
             //User pressed 'Logout' 
-            TwitchPlugin.PluginLog.Info("TwitchPlugin OnTwitchAccountOnLogoutRequested");
+            TwitchPlugin.PluginLog.Info("TwitchPlugin OnTwitchAccountOnLogoutRequested: Reporting Logout");
 
             // Asking Proxy here.,
             this._twitchAccount.AccessToken = null;
             this._twitchAccount.RefreshToken = null;
             TwitchPlugin.Proxy.Disconnect();
-
+            TwitchPlugin.PluginLog.Info("Reporting Logout");
             this._twitchAccount.ReportLogout(); //So that we force login for the next time
         }
 
@@ -153,7 +153,7 @@
            
             if( this._incorrectLoginErrors++ > MaxIncorrectLoginErrors )
             {
-                TwitchPlugin.PluginLog.Warning("Too many incorrect logins. Reporting disconnect");
+                TwitchPlugin.PluginLog.Warning("Too many incorrect logins. Reporting logout");
 
                 // Incorrect login happens when we are re-authenticating. Let's ignore it for now
                 this._twitchAccount.ReportLogout();
@@ -174,7 +174,7 @@
 
         private void OnConnected(Object sender, EventArgs e)
         {
-            TwitchPlugin.PluginLog.Info($"Connected to twitch client");
+            TwitchPlugin.PluginLog.Info($"Connected to twitch client. Reporting Login.");
             this._incorrectLoginErrors = 0;
             this.OnPluginStatusChanged(Loupedeck.PluginStatus.Normal, "Connected!");
         }
@@ -229,7 +229,7 @@
                 TwitchPlugin.PluginLog.Info($"TwitchPlugin OnOnlineFileContentReceived: token not cached or invalid. Need manual relogin. Access Token Empty={String.IsNullOrEmpty(this._twitchAccount.AccessToken)}. Refresh Token Empty={String.IsNullOrEmpty(this._twitchAccount.RefreshToken)}");
                 this._twitchAccount.AccessToken = null;
                 this._twitchAccount.RefreshToken = null;
-             
+                TwitchPlugin.PluginLog.Info("Reporting Logout");
                 this._twitchAccount.ReportLogout();
             }
         }

--- a/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
+++ b/TwitchPlugin/TwitchPlugin/metadata/LoupedeckPackage.yaml
@@ -15,7 +15,7 @@ displayName: Twitch
 pluginFileName: TwitchPlugin.dll
 
 # Plugin version.
-version: 5.8.1.10000
+version: 5.8.1.10001
 
 # Author of the plugin. The author can be a company or an individual developer.
 author: Andrei Laperie, Loupedeck


### PR DESCRIPTION
Replacing implicit auth with authorization code authentication is back for Twitch Plugin
Now it should survive over PC  being off when token expires. 

Fixing issue #5 